### PR TITLE
Disable squash-and-merge submission

### DIFF
--- a/otterdog/eclipse-pde.jsonnet
+++ b/otterdog/eclipse-pde.jsonnet
@@ -34,6 +34,7 @@ orgs.newOrg('eclipse-pde') {
     },
     orgs.newRepo('eclipse.pde') {
       default_branch: "master",
+      allow_squash_merge: false,
       delete_branch_on_merge: false,
       has_discussions: true,
       has_projects: false,


### PR DESCRIPTION
Using Github's Squash-and-merge submission method obfuscates the Committer of a change because the value of the committer field is `GitHub <noreply@github.com>` and not the Name and email of the real committer.

See for example https://github.com/eclipse-pde/eclipse.pde/pull/1455#issuecomment-2437524603